### PR TITLE
Namespace update and bug fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+## macOS
+.DS_Store
+
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3

--- a/FlatBuffer/include/flatbuffers/idl.h
+++ b/FlatBuffer/include/flatbuffers/idl.h
@@ -337,6 +337,7 @@ struct IDLOptions {
   bool generate_all;
   bool skip_unexpected_fields_in_json;
   bool generate_name_strings;
+  std::string objc_namespace;
 
   // Possible options for the more general generator below.
   enum Language { kJava, kCSharp, kGo, kMAX };
@@ -356,6 +357,7 @@ struct IDLOptions {
       generate_all(false),
       skip_unexpected_fields_in_json(false),
       generate_name_strings(false),
+      objc_namespace(""),
       lang(IDLOptions::kJava) {}
 };
 

--- a/FlatBuffer/src/flatc.cpp
+++ b/FlatBuffer/src/flatc.cpp
@@ -126,6 +126,7 @@ static void Error(const std::string &err, bool usage, bool show_exe_name) {
       "                     This may crash flatc given a mismatched schema.\n"
       "  --proto            Input is a .proto, translate to .fbs.\n"
       "  --schema           Serialize schemas instead of JSON (use with -b)\n"
+      "  --objc-namespace   For Objective-C only, use the string supplied as the global namespace for each file.\n"
       "FILEs may be schemas, or JSON files (conforming to preceding schema)\n"
       "FILEs after the -- must be binary flatbuffer format files.\n"
       "Output files are named using the base file name of the input,\n"
@@ -197,6 +198,9 @@ int main(int argc, const char *argv[]) {
         opts.proto_mode = true;
       } else if(arg == "--schema") {
         schema_binary = true;
+      } else if(arg == "--objc-namespace") {
+        if (++argi >= argc) Error("Missing Objective-C Namespace: " + arg, true);
+        opts.objc_namespace = std::string(argv[argi]);
       } else if(arg == "-M") {
         print_make_rules = true;
       } else if(arg == "--version") {

--- a/FlatBuffer/src/idl_gen_objc.cpp
+++ b/FlatBuffer/src/idl_gen_objc.cpp
@@ -94,17 +94,21 @@ namespace flatbuffers {
         public:
             
             static std::string nameSpace(const Parser &parser) {
-                
                 std::string namespace_general;
-        
-                auto &namespaces = parser.namespaces_.back()->components;
-                
-                for (auto it = namespaces.begin(); it != namespaces.end(); ++it) {
+                // If the user supplied a specific namespace to use for objective-C, use it,
+                // otherwise the default behavior is to concatenate namespaces into a single
+                // string.
+                if (parser.opts.objc_namespace.length() > 0) {
+                    namespace_general = parser.opts.objc_namespace;
+                } else {
 
-                    namespace_general += *it;
-                    
+                    auto &namespaces = parser.namespaces_.back()->components;
+
+                    for (auto it = namespaces.begin(); it != namespaces.end(); ++it) {
+                        namespace_general += *it;
+                    }
                 }
-                
+
                 return namespace_general;
             }
             
@@ -503,7 +507,7 @@ namespace flatbuffers {
                 // That, and Java Enums are expensive, and not universally liked.
                 
                 GenComment(enum_def.doc_comment, code_ptr, &lang.comment_config);
-                code += lang.enum_decl + GenTypeBasic(enum_def.underlying_type.base_type)+nameSpace(parser) + ", " + enum_def.name + ") ";
+                code += lang.enum_decl + GenTypeBasic(enum_def.underlying_type.base_type) + ", " + enum_def.name + ") ";
                 code += lang.open_curly;
 
                 for (auto it = enum_def.vals.vec.begin();

--- a/FlatBuffer/src/idl_gen_objc.cpp
+++ b/FlatBuffer/src/idl_gen_objc.cpp
@@ -507,7 +507,7 @@ namespace flatbuffers {
                 // That, and Java Enums are expensive, and not universally liked.
                 
                 GenComment(enum_def.doc_comment, code_ptr, &lang.comment_config);
-                code += lang.enum_decl + GenTypeBasic(enum_def.underlying_type.base_type) + ", " + enum_def.name + ") ";
+                code += lang.enum_decl + GenTypeBasic(enum_def.underlying_type.base_type) + ", " + nameSpace(parser) + enum_def.name + ") ";
                 code += lang.open_curly;
 
                 for (auto it = enum_def.vals.vec.begin();


### PR DESCRIPTION
- Adds a namespace option for objective-c. We have a case where we don't want our full package name to be turned into one long string. Maybe not standard flatbuffer idiom, but our flatbuffers live under com.company.project.fbs which leads to a nasty Objective-C name, `comcompanyprojectfbsObject`. This PR adds a `flatc` argument that allows you to specify a single 3-letter-namespace, the old objc way. `flatc -oc --objc-namespace FBS …`.

- Fixes issue with enums where the base type gets the namespace appended to the end. `typedef NS_ENUM(int8_tcomcompanyprojectfbs, EnumType) {…` which seems incorrect. I haven't tested all scenarios, but I can't imagine wanting to append a namespace after the type like that.

- Adds .gitignore for Xcode and macOS files to ignore.